### PR TITLE
masonpublishing/OJS-Theme#15: Add hook Templates::Article::Footer::PageFooter

### DIFF
--- a/templates/article/footer.tpl
+++ b/templates/article/footer.tpl
@@ -57,6 +57,7 @@
 	{$pageFooter}
 {/if}
 {call_hook name="Templates::Common::Footer::PageFooter"}
+{call_hook name="Templates::Article::Footer::PageFooter"}
 	<div id="standardFooter">
 		{if $issn}
 			<p>ISSN: {$issn}</p>


### PR DESCRIPTION
Add missing hook into `templates/article/footer.tpl`, leaving existing (perhaps spurious?) hook in place.

Installs which have used the `Templates::Common::Footer::PageFooter` for article usage will still work; installs which expect `Templates::Article::Footer::PageFooter` will now work.  If anyone has worked around this discrepancy by calling both, they will need to resolve this manually.